### PR TITLE
Correct errors with last bidder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /flashbots_mpc/Player-Data/*.pem
 /flashbots_mpc/Player-Data/*.key
 /flashbots_mpc/Player-Data/*.0
+
+__pycache__

--- a/mpc_knapsack_auction/README.md
+++ b/mpc_knapsack_auction/README.md
@@ -14,7 +14,7 @@ cd MP-SPDZ
 ```
 ### Choice of which MPC protocol to run
 For this experiment, we used a malicious shamir protocol as it is one of the most efficient protocol in the malicious, honest majority settings and
-it's a reasonable model for the flashbots setting. You can compile via running `make mal-shamir` after running the [MP-SPDZ installation instructions](https://github.com/data61/MP-SPDZ#tldr-binary-distribution-on-linux-or-source-distribution-on-macos).
+it's a reasonable model for the flashbots setting. You can compile via running `make malicious-shamir-party.x` after running the [MP-SPDZ installation instructions](https://github.com/data61/MP-SPDZ#tldr-binary-distribution-on-linux-or-source-distribution-on-macos).
 However, there are other potential reasonable MPC settings for this as well. Read the [MP-SPDZ README](https://github.com/data61/MP-SPDZ#preface) to learn more about decide which setting you'd like to try.
 
 ## Running the computation

--- a/mpc_knapsack_auction/knapsack_auction.mpc
+++ b/mpc_knapsack_auction/knapsack_auction.mpc
@@ -61,4 +61,4 @@ for bidder in bidders:
 bidder_matrix.sort()
 highest_bidder = bidder_matrix[0]
 
-knapsack_auction(bidder_matrix, 10,highest_bidder)
+knapsack_auction(bidder_matrix, 30000000,highest_bidder)

--- a/mpc_knapsack_auction/knapsack_auction.mpc
+++ b/mpc_knapsack_auction/knapsack_auction.mpc
@@ -22,8 +22,8 @@ def knapsack_auction(bidders, max_block_space, highest_bidder):
     def _(i):
         #nonlocal actual_capacity_of_solution
         current_bidder = bidders[i]
-        capacity_to_add = (actual_capacity_of_solution <= max_block_space).if_else(current_bidder[2], 0)
-        bidder_to_add = (actual_capacity_of_solution <= max_block_space).if_else(current_bidder, False)
+        capacity_to_add = (actual_capacity_of_solution + current_bidder[2] <= max_block_space).if_else(current_bidder[2], 0)
+        bidder_to_add = (actual_capacity_of_solution + current_bidder[2] <= max_block_space).if_else(current_bidder, False)
         actual_solution.append(bidder_to_add)
         actual_capacity_of_solution.iadd(capacity_to_add)
         return i+1
@@ -61,4 +61,4 @@ for bidder in bidders:
 bidder_matrix.sort()
 highest_bidder = bidder_matrix[0]
 
-knapsack_auction(bidder_matrix,30000000,highest_bidder)
+knapsack_auction(bidder_matrix, 10,highest_bidder)

--- a/mpc_knapsack_auction/knapsack_auction.mpc
+++ b/mpc_knapsack_auction/knapsack_auction.mpc
@@ -18,7 +18,7 @@ def knapsack_auction(bidders, max_block_space, highest_bidder):
     #counter = MemValue(0)
     n_bidders = bidders.sizes[0]
 
-    @while_do(lambda x: x < n_bidders, regint(0))
+    @for_range(n_bidders)
     def _(i):
         #nonlocal actual_capacity_of_solution
         current_bidder = bidders[i]
@@ -26,7 +26,6 @@ def knapsack_auction(bidders, max_block_space, highest_bidder):
         bidder_to_add = (actual_capacity_of_solution + current_bidder[2] <= max_block_space).if_else(current_bidder, False)
         actual_solution.append(bidder_to_add)
         actual_capacity_of_solution.iadd(capacity_to_add)
-        return i+1
         
 
     surplus = 0

--- a/mpc_knapsack_auction/knapsack_auction.py
+++ b/mpc_knapsack_auction/knapsack_auction.py
@@ -21,7 +21,7 @@ def knapsack_auction(bidders, max_weight, highest_bidder):
     allocation_capacity = 0
     winning_bidders = []
 
-    while (allocation_capacity <= max_weight) and (current_bidder := next(bidders_iterator, None)):
+    while (current_bidder := next(bidders_iterator, None)) and (allocation_capacity + current_bidder.allocation <= max_weight):
         allocation_capacity += current_bidder.allocation
         winning_bidders.append(current_bidder)
 


### PR DESCRIPTION
This PR aims to solve the problem shown in https://github.com/hashcloak/flashbots-privacy/issues/18. The solution is to consider the weight of the current bid inside the condition.